### PR TITLE
feat: Implementar controlador REST para Libro con endpoints CRUD

### DIFF
--- a/sistemaBiblioteca/src/main/java/org/example/sistemabiblioteca/controlador/LibroController.java
+++ b/sistemaBiblioteca/src/main/java/org/example/sistemabiblioteca/controlador/LibroController.java
@@ -1,0 +1,77 @@
+package org.example.sistemabiblioteca.controlador;
+
+import org.example.sistemabiblioteca.modelo.Libro;
+import org.example.sistemabiblioteca.servicio.LibroService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/libros")
+public class LibroController {
+
+    private final LibroService libroService;
+
+    public LibroController(LibroService libroService) {
+        this.libroService = libroService;
+    }
+
+    /**
+     * GET /api/libros
+     * Devuelve la lista completa de libros
+     */
+    @GetMapping
+    public List<Libro> obtenerTodos() {
+        return libroService.obtenerTodos();
+    }
+
+    /**
+     * GET /api/libros/{id}
+     * Devuelve un libro por su ID
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<Libro> obtenerPorId(@PathVariable Long id) {
+        try {
+            return ResponseEntity.ok(libroService.buscarPorId(id));
+        } catch (RuntimeException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    /**
+     * POST /api/libros
+     * Crea un nuevo libro
+     */
+    @PostMapping
+    public ResponseEntity<Libro> crear(@RequestBody Libro libro) {
+        return ResponseEntity.ok(libroService.guardar(libro));
+    }
+
+    /**
+     * PUT /api/libros/{id}
+     * Actualiza un libro existente por su ID
+     */
+    @PutMapping("/{id}")
+    public ResponseEntity<Libro> actualizar(@PathVariable Long id, @RequestBody Libro libro) {
+        try {
+            return ResponseEntity.ok(libroService.actualizar(id, libro));
+        } catch (RuntimeException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    /**
+     * DELETE /api/libros/{id}
+     * Elimina un libro por su ID
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> eliminar(@PathVariable Long id) {
+        try {
+            libroService.eliminar(id);
+            return ResponseEntity.noContent().build();
+        } catch (RuntimeException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+}


### PR DESCRIPTION
### 📌 Descripción

Se implementa el controlador `LibroController` que expone los endpoints necesarios para realizar operaciones CRUD sobre los recursos de tipo `Libro`.

### ✅ Cambios realizados

- Clase `LibroController` creada en el package `controlador`
- Endpoints implementados:
  - `GET /api/libros`
  - `GET /api/libros/{id}`
  - `POST /api/libros`
  - `PUT /api/libros/{id}`
  - `DELETE /api/libros/{id}`
- Inyección del servicio `LibroService` por constructor
- Manejo básico de errores con `try/catch` y `ResponseEntity`

### 🧩 Issue relacionado

Closes #8 

### 🏷️ Labels

- `controller`
- `enhancement`

### 🧪 Cómo probarlo

1. Ejecutar la aplicación
2. Realizar peticiones HTTP a `/api/libros`
3. Verificar respuestas correctas (200 OK, 404 Not Found, etc.)
