### PR TITLE
feat: Implementar controladores REST para Usuario y Prestamo

### DIFF
--- a/sistemaBiblioteca/src/main/java/org/example/sistemabiblioteca/controlador/PrestamoController.java
+++ b/sistemaBiblioteca/src/main/java/org/example/sistemabiblioteca/controlador/PrestamoController.java
@@ -1,0 +1,72 @@
+package org.example.sistemabiblioteca.controlador;
+
+import org.example.sistemabiblioteca.modelo.Prestamo;
+import org.example.sistemabiblioteca.servicio.PrestamoService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/prestamos")
+public class PrestamoController {
+
+    private final PrestamoService prestamoService;
+
+    public PrestamoController(PrestamoService prestamoService) {
+        this.prestamoService = prestamoService;
+    }
+
+    /**
+     * GET /api/prestamos
+     */
+    @GetMapping
+    public List<Prestamo> obtenerTodos() {
+        return prestamoService.obtenerTodos();
+    }
+
+    /**
+     * GET /api/prestamos/{id}
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<Prestamo> obtenerPorId(@PathVariable Long id) {
+        try {
+            return ResponseEntity.ok(prestamoService.buscarPorId(id));
+        } catch (RuntimeException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    /**
+     * POST /api/prestamos
+     */
+    @PostMapping
+    public ResponseEntity<Prestamo> crear(@RequestBody Prestamo prestamo) {
+        return ResponseEntity.ok(prestamoService.guardar(prestamo));
+    }
+
+    /**
+     * PUT /api/prestamos/{id}
+     */
+    @PutMapping("/{id}")
+    public ResponseEntity<Prestamo> actualizar(@PathVariable Long id, @RequestBody Prestamo prestamo) {
+        try {
+            return ResponseEntity.ok(prestamoService.actualizar(id, prestamo));
+        } catch (RuntimeException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    /**
+     * DELETE /api/prestamos/{id}
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> eliminar(@PathVariable Long id) {
+        try {
+            prestamoService.eliminar(id);
+            return ResponseEntity.noContent().build();
+        } catch (RuntimeException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+}

--- a/sistemaBiblioteca/src/main/java/org/example/sistemabiblioteca/controlador/UsuarioController.java
+++ b/sistemaBiblioteca/src/main/java/org/example/sistemabiblioteca/controlador/UsuarioController.java
@@ -1,0 +1,72 @@
+package org.example.sistemabiblioteca.controlador;
+
+import org.example.sistemabiblioteca.modelo.Usuario;
+import org.example.sistemabiblioteca.servicio.UsuarioService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/usuarios")
+public class UsuarioController {
+
+    private final UsuarioService usuarioService;
+
+    public UsuarioController(UsuarioService usuarioService) {
+        this.usuarioService = usuarioService;
+    }
+
+    /**
+     * GET /api/usuarios
+     */
+    @GetMapping
+    public List<Usuario> obtenerTodos() {
+        return usuarioService.obtenerTodos();
+    }
+
+    /**
+     * GET /api/usuarios/{id}
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<Usuario> obtenerPorId(@PathVariable Long id) {
+        try {
+            return ResponseEntity.ok(usuarioService.buscarPorId(id));
+        } catch (RuntimeException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    /**
+     * POST /api/usuarios
+     */
+    @PostMapping
+    public ResponseEntity<Usuario> crear(@RequestBody Usuario usuario) {
+        return ResponseEntity.ok(usuarioService.guardar(usuario));
+    }
+
+    /**
+     * PUT /api/usuarios/{id}
+     */
+    @PutMapping("/{id}")
+    public ResponseEntity<Usuario> actualizar(@PathVariable Long id, @RequestBody Usuario usuario) {
+        try {
+            return ResponseEntity.ok(usuarioService.actualizar(id, usuario));
+        } catch (RuntimeException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    /**
+     * DELETE /api/usuarios/{id}
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> eliminar(@PathVariable Long id) {
+        try {
+            usuarioService.eliminar(id);
+            return ResponseEntity.noContent().build();
+        } catch (RuntimeException e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+}


### PR DESCRIPTION
### 📌 Descripción

Se implementan los controladores REST `UsuarioController` y `PrestamoController` como parte de la Etapa 3 del sistema.

Cada controlador expone los endpoints básicos para realizar operaciones CRUD sobre las entidades `Usuario` y `Prestamo`.

### ✅ Cambios realizados

- Clase `UsuarioController`:
  - `GET /api/usuarios`
  - `GET /api/usuarios/{id}`
  - `POST /api/usuarios`
  - `PUT /api/usuarios/{id}`
  - `DELETE /api/usuarios/{id}`

- Clase `PrestamoController`:
  - `GET /api/prestamos`
  - `GET /api/prestamos/{id}`
  - `POST /api/prestamos`
  - `PUT /api/prestamos/{id}`
  - `DELETE /api/prestamos/{id}`

- Ambos controladores:
  - Inyección por constructor del servicio correspondiente (`UsuarioService` y `PrestamoService`)
  - Manejo básico de errores (retorna 404 si no se encuentra el recurso)

### 🧩 Issue relacionado

Closes #9 

### 🏷️ Labels

- `controller`
- `enhancement`

### 🧪 Cómo probarlo

1. Ejecutar la aplicación (`SistemaBibliotecaApplication`)
2. Probar los endpoints usando Postman, curl o similar:
   - Crear, listar, buscar, actualizar y eliminar `usuarios` y `prestamos`
3. Verificar que las respuestas HTTP sean correctas (200, 201, 204, 404)
