### PR TITLE
test: Agregar tests de integración para LibroController con MockMvc

### DIFF
--- a/sistemaBiblioteca/src/test/java/org/example/sistemabiblioteca/servicio/LibroControllerTest.java
+++ b/sistemaBiblioteca/src/test/java/org/example/sistemabiblioteca/servicio/LibroControllerTest.java
@@ -1,0 +1,56 @@
+package org.example.sistemabiblioteca.controlador;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.sistemabiblioteca.modelo.EstadoLibro;
+import org.example.sistemabiblioteca.modelo.Libro;
+import org.example.sistemabiblioteca.servicio.LibroService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(LibroController.class)
+class LibroControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LibroService libroService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void obtenerTodos_deberiaRetornarListaDeLibros() throws Exception {
+        Libro libro = new Libro(1L, "123", "Test", "Autor", EstadoLibro.DISPONIBLE);
+        when(libroService.obtenerTodos()).thenReturn(List.of(libro));
+
+        mockMvc.perform(get("/api/libros"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].titulo").value("Test"));
+    }
+
+    @Test
+    void crearLibro_deberiaRetornarLibroGuardado() throws Exception {
+        Libro libro = new Libro(null, "456", "Nuevo", "Autor", EstadoLibro.DISPONIBLE);
+        Libro guardado = new Libro(2L, "456", "Nuevo", "Autor", EstadoLibro.DISPONIBLE);
+
+        when(libroService.guardar(libro)).thenReturn(guardado);
+
+        mockMvc.perform(post("/api/libros")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(libro)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(2))
+                .andExpect(jsonPath("$.isbn").value("456"));
+    }
+}


### PR DESCRIPTION
### 📌 Descripción

Se agregan tests de integración para el controlador `LibroController` utilizando la herramienta `MockMvc`.

Se prueban distintos endpoints simulando peticiones HTTP reales, verificando tanto el código de estado (status) como el contenido de la respuesta JSON.

### ✅ Cambios realizados

- Clase `LibroControllerTest` ubicada en `src/test/java/org/example/sistemabiblioteca/controlador`
- Se utilizó:
  - `@WebMvcTest(LibroController.class)`
  - `@MockBean LibroService`
  - `MockMvc` para simular requests
  - `ObjectMapper` para serialización JSON
- Se probaron:
  - `GET /api/libros` → lista de libros
  - `POST /api/libros` → creación de nuevo libro

### 🧩 Issue relacionado

Closes #11 

### 🏷️ Labels

- `testing`

### 🧪 Cómo probarlo

1. Ejecutar la clase `LibroControllerTest` desde el IDE o con Maven (`mvn test`)
2. Verificar que los tests pasen correctamente:
   - Respuesta con JSON válido
   - Status HTTP correctos (200 OK, etc.)
